### PR TITLE
Check if volumes is available

### DIFF
--- a/attach_volume.py
+++ b/attach_volume.py
@@ -60,7 +60,8 @@ def find(tag, val, client=None):
     try:
         for x in c.describe_volumes(Filters=[filters(tag, val)])['Volumes']:
             if x['AvailabilityZone'] == zone():
-                return x
+                if x['State'] == 'available':
+                    return x
     except Exception, e:
         print(e)
         sys.exit(2)


### PR DESCRIPTION
Select first available volume. I encountered a problem with lots of volumes under the same tag/val pair and multiple hosts just trying to mount the same first volume on the list. Now it finds the first available volume under the same tag/val pair.